### PR TITLE
Fix bioconda channel typo

### DIFF
--- a/modules/local/gtftools/length/main.nf
+++ b/modules/local/gtftools/length/main.nf
@@ -2,7 +2,7 @@ process GTFTOOLS_LENGTH {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda:gtftools=0.9.0-0"
+    conda "bioconda::gtftools=0.9.0-0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/gtftools:0.9.0--pyh5e36f6f_0':
         'biocontainers/gtftools:0.9.0--pyh5e36f6f_0' }"

--- a/modules/local/motifs/convert_motifs/main.nf
+++ b/modules/local/motifs/convert_motifs/main.nf
@@ -2,7 +2,7 @@ process CONVERT_MOTIFS {
     tag "$meta.id"
     label "process_single"
 
-    conda "bioconda:bioconductor-universalmotif==1.20.0--r43hf17093f_0"
+    conda "bioconda::bioconductor-universalmotif==1.20.0--r43hf17093f_0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/bioconductor-universalmotif:1.20.0--r43hf17093f_0':
         'biocontainers/bioconductor-universalmotif:1.20.0--r43hf17093f_0' }"


### PR DESCRIPTION
Only one `:` instead of two `::`.

General note - I'd prefer having `environment.yml` files for every local module and then using `conda "${moduleDir}/environment.yml"`. Then the conda channels can be specified within and the files are a bit easier to discover / automate around and maintain.
