### PR TITLE
Merge samples fix bedtools merge

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -97,7 +97,8 @@ process {
         ext.prefix = {"${meta.id}.sorted"}
     }
 
-    withName: BEDTOOLS_MERGE {
+    withName: ".*:MERGE_SAMPLES:BEDTOOLS_MERGE" {
+        ext.args = "-c 1 -o count"
         ext.prefix = {"${meta.id}.merged"}
     }
 

--- a/subworkflows/local/merge_samples.nf
+++ b/subworkflows/local/merge_samples.nf
@@ -20,8 +20,6 @@ workflow MERGE_SAMPLES {
                     .map{ meta, peak_file -> [meta + [id: meta.condition + "_" + meta.assay], peak_file]}
                     .groupTuple()
 
-    // ch_grouped.view()
-
     CONCAT_SAMPLES(ch_grouped)
     BEDTOOLS_SORT(CONCAT_SAMPLES.out.file_out, [])
     BEDTOOLS_MERGE(BEDTOOLS_SORT.out.sorted)


### PR DESCRIPTION
Fixed the `BEDTOOLS_MERGE` according to the [bedtools documentation](https://bedtools.readthedocs.io/en/latest/content/tools/merge.html#c-and-o-applying-operations-to-columns-from-merged-intervals).
Cannot use the more convenient`bedtools merge -n` since it is deprecated since `2.20.2`.

Additionally, removed a debugging statement.