### PR TITLE
Fix STARE error

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -22,7 +22,7 @@ process {
         ext.args = "-l \"gene_id,gene_name\""
     }
 
-    withName: CLEAN_BED {
+    withName: ".*:PEAKS:CLEAN_BED" {
         ext.args = {"'{print \$1 \"\\t\" \$2 \"\\t\" \$3 \"\\t\" \$4 \"\\t\" \$5 \"\\t\" \$6}'"}
         ext.prefix = {"${meta.id}.clean"}
         ext.suffix = "bed"
@@ -100,6 +100,12 @@ process {
     withName: ".*:MERGE_SAMPLES:BEDTOOLS_MERGE" {
         ext.args = "-c 1 -o count"
         ext.prefix = {"${meta.id}.merged"}
+    }
+
+    withName: ".*:MERGE_SAMPLES:CLEAN_BED" {
+        ext.args = "'{print \$1 \"\\t\" \$2 \"\\t\" \$3}'"
+        ext.prefix = {"${meta.id}.clean"}
+        ext.suffix = "bed"
     }
 
     withName: ANNOTATE_SAMPLES {


### PR DESCRIPTION
When running the pipeline with ` merge_samples = true`, the last step of the `MERGE_SAMPLES` workflow cleans the bed file and formats it to 6 columns. If the input bed file has less than 6 columns it simply appends trailing `\t` which breaks `STARE`. I therefore split the module configuration and just use the first 3 columns im `MERGE_SAMPLES` as the fourth one is just the number of elements merged from the previous process.