### PR TITLE
Adjust pipeline level output

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -13,8 +13,9 @@
 process {
 
     publishDir = [
-        path: { "${params.outdir}/all/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+        path: { "${params.outdir}/all/${(task.process.tokenize(':')[1] == 'TFACTIVITY' ? task.process.tokenize(':')[2..-1] : task.process.tokenize(':')[1..-1])*.toLowerCase().join('/')}" },
         mode: params.publish_dir_mode,
+        enabled: params.save_all_outputs,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,7 +54,7 @@ params {
     // Boilerplate options
     outdir                       = null
     publish_dir_mode             = 'copy'
-    save_intermediates           = false
+    save_all_outputs             = false
     email                        = null
     email_on_fail                = null
     plaintext_email              = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -54,6 +54,7 @@ params {
     // Boilerplate options
     outdir                       = null
     publish_dir_mode             = 'copy'
+    save_intermediates           = false
     email                        = null
     email_on_fail                = null
     plaintext_email              = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -61,6 +61,12 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "save_intermediates": {
+                    "type": "boolean",
+                    "description": "Save intermediate files.",
+                    "fa_icon": "fas fa-save",
+                    "help_text": "If set to `true`, the pipeline will save all intermediate files to the output directory. This is useful for debugging and for keeping track of the pipeline's progress."
+                },
                 "email": {
                     "type": "string",
                     "description": "Email address for completion summary.",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -61,11 +61,11 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
-                "save_intermediates": {
+                "save_all_outputs": {
                     "type": "boolean",
-                    "description": "Save intermediate files.",
+                    "description": "Save all output files.",
                     "fa_icon": "fas fa-save",
-                    "help_text": "If set to `true`, the pipeline will save all intermediate files to the output directory. This is useful for debugging and for keeping track of the pipeline's progress."
+                    "help_text": "If set to `true`, the pipeline will save all intermediate output files to the output directory. This is useful for debugging and for keeping track of the pipeline's progress."
                 },
                 "email": {
                     "type": "string",


### PR DESCRIPTION
Adjusting the pipeline level output, s.t. not everything is copied into the `output/all` folder.
Currently some outputs are also merged, since they end up in the same directory with this command: `"${params.outdir}/all/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}"`