### PR TITLE
Fix report caching

### DIFF
--- a/modules/local/report/preprocess/templates/preprocess.py
+++ b/modules/local/report/preprocess/templates/preprocess.py
@@ -50,6 +50,7 @@ metadata = {
 }
 
 params = yaml.load(open(params_path), yaml.CSafeLoader)
+params = {k: v for k, v in params.items() if v is not None}
 json.dump(params, open("params.json", "w"), indent=4)
 
 ranking = {}

--- a/subworkflows/local/utils_nfcore_tfactivity_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_tfactivity_pipeline/main.nf
@@ -260,6 +260,9 @@ def paramsSummaryToYAML(summary_params) {
                     .keySet()
                     .sort()
                     .each { param ->
+                        if (param == "runName" || param == "trace_report_suffix") {
+                            return // skip these keys to stabilize the hashes
+                        }
                         def value = group_params.get(param)
                         yaml_file_text += "  ${param}: ${value ?: 'null'}\n"
                     }


### PR DESCRIPTION
The problem is that each run is assigned with a random run name (something like `stupefied_khorana` and a time-based `trace_report_suffix` (such as `2025-07-12_13-04-06`). These are stored in params. As these params are included in the input of the report creation, the hashes change with every run.

As I can't imagine these parameter values to be helpful in any real-world scenario, I think we can exclude these params from the report, thus stabilizing the hashes. This PR implements these changes