### PR TITLE
fix sneep empty output error

### DIFF
--- a/modules/local/sneep/run_sneep/main.nf
+++ b/modules/local/sneep/run_sneep/main.nf
@@ -14,7 +14,7 @@ process RUN_SNEEP {
     path scale_file
 
     output:
-    tuple val(meta), path("sneep_${meta.id}/PFMs/*.txt"), emit: pfms
+    tuple val(meta), path("sneep_${meta.id}/PFMs/*.txt"), emit: pfms, optional: true
     tuple val(meta), path("sneep_${meta.id}/InDels.bed"), emit: indels
     tuple val(meta), path("sneep_${meta.id}/info.txt"), emit: info
     tuple val(meta), path("sneep_${meta.id}/motifInfo.txt"), emit: motifinfo


### PR DESCRIPTION
If Sneep finds no hits, it generates an empty `results.txt` and does not create any `PFM/*.txt` files. This PR marks the PFM output as optional to prevent the pipeline from failing in such cases.

<!--
# nf-core/tfactivity pull request

Many thanks for contributing to nf-core/tfactivity!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/tfactivity/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/tfactivity/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/tfactivity _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
